### PR TITLE
gather_script dumps the deployer database

### DIFF
--- a/charts/ccx/scripts/gather-logs.sh
+++ b/charts/ccx/scripts/gather-logs.sh
@@ -81,8 +81,10 @@ done
 
 echo Dumping CCX tables...
 export DB_DSN=$(kubectl ${NAMESPACE} get secret db -o jsonpath='{.data.DB_DSN}' | base64 --decode)
+export DEPLOYER_DB_DSN=$(kubectl ${NAMESPACE} get secret db-deployer -o jsonpath='{.data.DEPLOYER_DB_DSN}' | base64 --decode)
 kubectl ${NAMESPACE} run -it --rm psql --image=postgres:15-alpine --restart=Never -- pg_dump ${DB_DSN} -x -O -t cluster_config_parameters -t cluster_firewalls -t cluster_hosts -t clusters -t controllers -t databases -t darwin_migrations -t vpc -t vpc_subnets > ${dir}/ccx_tables_dump.sql
 kubectl ${NAMESPACE} run -it --rm psql --image=postgres:15-alpine --restart=Never -- pg_dump ${DB_DSN} -x -O -t job_messages -t jobs > ${dir}/ccx_jobs_dump.sql
+kubectl ${NAMESPACE} run -it --rm psql --image=postgres:15-alpine --restart=Never -- pg_dump ${DEPLOYER_DB_DSN} -x -O > ${dir}/ccx_deployer_tables_dump.sql
 
 echo Archiving logs...
 tar -zcf ${OUTPUT_FILE} -C ${dir} .


### PR DESCRIPTION
## Pull Request Checklist

### Description of Changes / Purpose / What Does It Change & Why
To facilitate debugging, we need a database dump of the deployer database, which maintains the state of deployed cloud resources. This dump will help us analyze the current state and troubleshoot any issues effectively.