### PR TITLE
Update chart to use MySQL chart version 2.0.17 because 2.0.16 is no longer available

### DIFF
--- a/charts/clustercontrol/Chart.yaml
+++ b/charts/clustercontrol/Chart.yaml
@@ -9,11 +9,11 @@ appVersion: "2.3.2-12518"
 
 dependencies:
   - name: mysql-operator
-    version: 2.0.16
+    version: 2.0.17
     repository: https://mysql.github.io/mysql-operator/
     condition: installMysqlOperator
   - name: mysql-innodbcluster
-    version: 2.0.16
+    version: 2.0.17
     repository: https://mysql.github.io/mysql-operator/
     condition: createDatabases
   - name: victoria-metrics-single


### PR DESCRIPTION
## Pull Request Checklist

### Description of Changes / Purpose / What Does It Change & Why
Need to change the MySQL chart version used to 2.0.17 because 2.0.16 is no longer available.


```
Packaging chart 'charts/clustercontrol'...
Using config file:  .github/ci/cr.yaml
Error: can't get a valid version for repositories mysql-operator, mysql-innodbcluster. Try changing the version constraint in Chart.yaml
Usage:
  cr package [CHART_PATH] [...] [flags]

Flags:
  -h, --help                     help for package
      --key string               Name of the key to use when signing
      --keyring string           Location of a public keyring (default "~/.gnupg/pubring.gpg")
  -p, --package-path string      Path to directory with chart packages (default ".cr-release-packages")
      --passphrase-file string   Location of a file which contains the passphrase for the signing key. Use '-' in order to read from stdin
      --sign                     Use a PGP private key to sign this package

Global Flags:
      --config string   Config file (default is $HOME/.cr.yaml)
```