### PR TITLE
CLUS-6060 use correct image tags & helm install pre-release builds

### DIFF
--- a/charts/clustercontrol/Chart.yaml
+++ b/charts/clustercontrol/Chart.yaml
@@ -4,7 +4,7 @@ description: A ClusterControl Helm Chart for Kubernetes
 
 type: application
 
-version: "2.3.2"
+version: "2.3.2-6"
 appVersion: "2.3.2-12981"
 
 dependencies:

--- a/charts/clustercontrol/README.md
+++ b/charts/clustercontrol/README.md
@@ -35,7 +35,7 @@ kubectl config set-context --current --namespace=clustercontrol
 ## Install
 
 ```
-helm install clustercontrol s9s/clustercontrol
+helm install clustercontrol s9s/clustercontrol --devel
 ```
 
 ## Providing your own SSH keys for ClusterControl to use
@@ -58,7 +58,7 @@ kubectl create secret generic my-ssh-keys --from-file=key1=/path/to/my/.ssh/id_r
 Providing cmon.sshKeysSecretName value with our secret name created above
 
 ```
-helm upgrade --install clustercontrol s9s/clustercontrol --set cmon.sshKeysSecretName=my-ssh-keys
+helm upgrade --install clustercontrol s9s/clustercontrol --set cmon.sshKeysSecretName=my-ssh-keys --devel
 ```
 
 ## Custom configuration via values.yaml
@@ -74,7 +74,7 @@ helm show values s9s/clustercontrol > values.yaml
 ### Install / Upgrade using your custom values.yaml
 
 ```
-helm install clustercontrol s9s/clustercontrol -f values.yaml
+helm install clustercontrol s9s/clustercontrol -f values.yaml --devel
 ```
 
 ## Notes
@@ -90,7 +90,7 @@ Is is *HIGHLY* recommended to use ingress as ClusterControl V2 requires cmon API
 ### If you already have Oracle MySQL Operator or NGINX ingress controller installed
 
 ```
-helm install clustercontrol s9s/clustercontrol --debug --set fqdn=clustercontrol.example.com --set installMysqlOperator=false --set ingressController.enabled=false
+helm install clustercontrol s9s/clustercontrol --debug --set fqdn=clustercontrol.example.com --set installMysqlOperator=false --set ingressController.enabled=false --devel
 ```
 
 This helm chart has certain dependencies that makes ClusterControl easier to install.

--- a/charts/clustercontrol/values.yaml
+++ b/charts/clustercontrol/values.yaml
@@ -72,14 +72,14 @@ cmon:
 #        cpu: 100m
 #        memory: 1Gi
   ccmgr:
-    image: europe-docker.pkg.dev/severalnines-public/clustercontrol/ccmgr:release-2.3.2
+    image: europe-docker.pkg.dev/severalnines-public/clustercontrol/ccmgr:release-2.3.2-28
     devImage: europe-docker.pkg.dev/severalnines-public/clustercontrol/ccmgr:main-dev-latest
 #    resources:
 #      requests:
 #        cpu: 100m
 #        memory: 1Gi
   kuberProxy:
-    image: europe-docker.pkg.dev/severalnines-public/clustercontrol/kuber-proxy:release-2.3.2
+    image: europe-docker.pkg.dev/severalnines-public/clustercontrol/kuber-proxy:release-0.1.0
     devImage: europe-docker.pkg.dev/severalnines-public/clustercontrol/kuber-proxy:main-dev-latest
 #    resources:
 #      requests:


### PR DESCRIPTION
https://severalnines.atlassian.net/browse/CLUS-6060

We need to use pre-release helm builds because we need to patch the patch (meaning: 2.3.2 is a patch already but we need to release patches for that version)

For the same reason we need to have build number in cmon-proxy image tag