### PR TITLE
Make gather-logs.sh DB dumps reliable for large databases

### DIFF
--- a/charts/ccx/scripts/gather-logs.sh
+++ b/charts/ccx/scripts/gather-logs.sh
@@ -98,16 +98,60 @@ echo Dumping CCX tables...
 export DB_DSN=$(kubectl ${NAMESPACE} get secret db -o jsonpath='{.data.DB_DSN}' | base64 --decode)
 export DEPLOYER_DB_DSN=$(kubectl ${NAMESPACE} get secret db-deployer -o jsonpath='{.data.DB_DSN}' | base64 --decode)
 
-# Run pg_dump inside a throwaway pod. Each call uses a UNIQUE pod name so that a
-# previous dump pod that is still terminating (or was left behind by an
-# interrupted run) cannot cause a `pods "psql" already exists` failure. Any
-# leftover pod with the same name is removed first as an extra safeguard.
-# The caller keeps stdout (the SQL) and stderr (kubectl/pg_dump messages)
-# separate so pod lifecycle text never ends up inside the .sql dump.
-pg_dump_in_pod() {
-    local podname="ccx-logs-pgdump-$$-${RANDOM}"
-    kubectl ${NAMESPACE} delete pod "${podname}" --ignore-not-found --now >/dev/null 2>&1
-    kubectl ${NAMESPACE} run -i --rm "${podname}" --quiet --image=postgres:15-alpine --restart=Never -- pg_dump "$@"
+# Dump a database from a throwaway pod and copy the result out with `kubectl cp`.
+#
+# We deliberately do NOT stream pg_dump's stdout over `kubectl run -i`/attach.
+# That path is unreliable for anything but tiny dumps: the attach stream races
+# the container exit ("couldn't attach to pod ..., falling back to streaming
+# logs"/"container not found"), and a multi-hundred-MB stream hits an i/o
+# timeout on the API-server connection and is SILENTLY TRUNCATED (no pg_dump
+# trailer) - or, on some environments, produces 0 bytes with an empty stderr
+# because `--rm` deleted the pod before any error surfaced.
+#
+# Instead: pg_dump writes to a file INSIDE the pod (compressed with gzip, so the
+# transfer is ~10x smaller), pg_dump's stderr is captured to a sidecar .err file
+# in the pod, and once it finishes we `kubectl cp` the finished files out. The
+# pod uses a UNIQUE name (no collisions), is created WITHOUT `--rm` (so it
+# survives long enough for the copy and so failures leave evidence), and is
+# deleted explicitly afterwards. The connection string is passed via an env var
+# so it never appears on a command line.
+#
+# Usage: dump_db <output-basename> <dsn> [pg_dump options...]
+#        produces <output-basename>.sql.gz and <output-basename>.err
+dump_db() {
+    local out="$1" dsn="$2"; shift 2
+    local pod="ccx-logs-pgdump-$$-${RANDOM}"
+    kubectl ${NAMESPACE} delete pod "${pod}" --ignore-not-found --now >/dev/null 2>&1
+    # The container dumps to /tmp, marks completion with /tmp/dump.done, then idles
+    # so `kubectl cp`/`exec` (which need a running container) can reach the files.
+    kubectl ${NAMESPACE} run "${pod}" --image=postgres:17-alpine --restart=Never \
+        --env="PGCONN=${dsn}" --command -- \
+        sh -c 'pg_dump "$@" "$PGCONN" 2>/tmp/dump.err | gzip > /tmp/dump.sql.gz; touch /tmp/dump.done; sleep 86400' \
+        sh "$@" >/dev/null 2>&1
+    kubectl ${NAMESPACE} wait --for=condition=Ready "pod/${pod}" --timeout=300s >/dev/null 2>&1
+    # Poll for completion (large dumps take minutes); cap the wait at ~1h.
+    local tries=0
+    until kubectl ${NAMESPACE} exec "${pod}" -- test -f /tmp/dump.done >/dev/null 2>&1; do
+        tries=$((tries + 1))
+        [ ${tries} -gt 720 ] && { echo "  WARNING: ${out} dump timed out" 1>&2; break; }
+        sleep 5
+    done
+    # Copy results out, verifying the copied size against the in-pod size.
+    # `kubectl cp` streams over the API server's exec channel, which can
+    # silently TRUNCATE a large file if the connection times out. Retrying
+    # recovers a transient cut; if it still can't complete we warn loudly
+    # rather than hand over a silently-corrupt dump.
+    local want got attempt
+    want=$(kubectl ${NAMESPACE} exec "${pod}" -- sh -c 'wc -c < /tmp/dump.sql.gz' 2>/dev/null | tr -d '[:space:]')
+    for attempt in 1 2 3; do
+        kubectl ${NAMESPACE} cp "${pod}:/tmp/dump.sql.gz" "${out}.sql.gz" >/dev/null 2>&1
+        got=$(wc -c < "${out}.sql.gz" 2>/dev/null | tr -d '[:space:]')
+        [ -n "${want}" ] && [ "${got}" = "${want}" ] && break
+        echo "  retrying copy of $(basename "${out}").sql.gz (${got:-0}/${want:-?} bytes)" 1>&2
+    done
+    [ "${got}" = "${want}" ] || echo "  WARNING: $(basename "${out}").sql.gz incomplete (${got:-0}/${want:-?} bytes) - re-run if needed" 1>&2
+    kubectl ${NAMESPACE} cp "${pod}:/tmp/dump.err" "${out}.err" >/dev/null 2>&1
+    kubectl ${NAMESPACE} delete pod "${pod}" --now >/dev/null 2>&1
 }
 
 # Dump the CCX database with an EXCLUDE list rather than a hand-maintained -t
@@ -123,19 +167,16 @@ pg_dump_in_pod() {
 #     (web_tokens, oauth2_*). KEEP THIS LIST UP TO DATE if new sensitive tables
 #     are added.
 #   * jobs / job_messages, which are large and dumped separately below.
-# Note: pg_dump takes the connection string / dbname as its final positional
-# argument, so it is passed last (after all options) for reliable parsing.
-pg_dump_in_pod -x -O \
+dump_db "${dir}/ccx_tables_dump" "${DB_DSN}" -x -O \
     --exclude-table='users*' \
     --exclude-table='admin_users' \
     --exclude-table='session*' \
     --exclude-table='web_tokens' \
     --exclude-table='oauth2_*' \
     --exclude-table='jobs' \
-    --exclude-table='job_messages' \
-    "${DB_DSN}" > "${dir}/ccx_tables_dump.sql" 2> "${dir}/ccx_tables_dump.err"
-pg_dump_in_pod -x -O -t job_messages -t jobs "${DB_DSN}" > "${dir}/ccx_jobs_dump.sql" 2> "${dir}/ccx_jobs_dump.err"
-pg_dump_in_pod -x -O "${DEPLOYER_DB_DSN}" > "${dir}/ccx_deployer_tables_dump.sql" 2> "${dir}/ccx_deployer_tables_dump.err"
+    --exclude-table='job_messages'
+dump_db "${dir}/ccx_jobs_dump" "${DB_DSN}" -x -O -t job_messages -t jobs
+dump_db "${dir}/ccx_deployer_tables_dump" "${DEPLOYER_DB_DSN}" -x -O
 
 echo Archiving logs...
 tar -zcf ${OUTPUT_FILE} -C ${dir} .


### PR DESCRIPTION
The previous version streamed `pg_dump` stdout over `kubectl run -i --rm` (attach). That path is unreliable for anything but tiny dumps:

- the attach stream races the container exit (`couldn't attach to pod ..., falling back to streaming logs` / `container not found`), and
- a multi-hundred-MB stream hits an i/o timeout on the API-server connection and is **silently truncated** (no `pg_dump` trailer) — or produces a 0-byte file with an empty `.err` because `--rm` deleted the pod before any error surfaced.

The net effect was support bundles that looked fine but contained empty or truncated SQL dumps.

## What changed

- `pg_dump` now writes to a file **inside** the pod, compressed with `gzip` (~10x smaller transfer), with its stderr captured to a sidecar `.err` file. Output files are now `*.sql.gz`.
- The dump pod is created **without** `--rm` (unique name, deleted explicitly after copy), so it survives long enough for the copy and leaves evidence on failure.
- The finished file is pulled out with `kubectl cp` and the copied size is **verified against the in-pod size**, retried on mismatch, and a loud warning is printed if it still can't complete — so a truncated transfer is never handed over as silently-corrupt data.
- The connection string is passed via an env var instead of on the command line.

## Testing

Ran against a live namespace with a multi-GB CCX database: the main dump (`ccx_tables_dump.sql.gz`, ~2.7 GB compressed) copies out intact, `gunzip -t` passes, and the decompressed SQL ends with the `PostgreSQL database dump complete` trailer. All non-sensitive tables (including the billing usage tables) are present and no `users*`/`session*`/`oauth2_*`/`web_tokens` tables are exported.